### PR TITLE
Fix token ttl

### DIFF
--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -17,7 +17,7 @@ async function createAndCacheToken (req, email) {
 }
 
 async function sendLoginEmail (email, token) {
-  return await sendEmail(templateIdFarmerLogin, email, {
+  return sendEmail(templateIdFarmerLogin, email, {
     personalisation: { magiclink: `${serviceUri}/verify-login?token=${token}&email=${email}` },
     reference: token
   })

--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -12,7 +12,15 @@ async function createAndCacheToken (req, email) {
   const tokens = await magiclinkCache.get(email) ?? []
   tokens.push(token)
   await magiclinkCache.set(email, tokens)
+  await magiclinkCache.set(token, email)
   return token
+}
+
+async function sendLoginEmail (email, token) {
+  return await sendEmail(templateIdFarmerLogin, email, {
+    personalisation: { magiclink: `${serviceUri}/verify-login?token=${token}&email=${email}` },
+    reference: token
+  })
 }
 
 module.exports = [{
@@ -60,10 +68,7 @@ module.exports = [{
 
       const token = await createAndCacheToken(request, email)
 
-      const result = await sendEmail(templateIdFarmerLogin, email, {
-        personalisation: { magiclink: `${serviceUri}/verify-login?token=${token}&email=${email}` },
-        reference: token
-      })
+      const result = await sendLoginEmail(email, token)
 
       if (!result) {
         return boom.internal()

--- a/app/routes/auth/verify-login.js
+++ b/app/routes/auth/verify-login.js
@@ -21,7 +21,7 @@ async function clearCache (request, email) {
 
 async function lookupToken (request, token) {
   const { magiclinkCache } = request.server.app
-  return await magiclinkCache.get(token)
+  return magiclinkCache.get(token)
 }
 
 module.exports = [{

--- a/app/routes/auth/verify-login.js
+++ b/app/routes/auth/verify-login.js
@@ -2,6 +2,28 @@ const Joi = require('joi')
 const { getByEmail } = require('../../api-requests/users')
 const { setOrganisation } = require('../../session')
 
+async function cacheUserData (request, email) {
+  const organisation = await getByEmail(email)
+  Object.entries(organisation).forEach(([k, v]) => setOrganisation(request, k, v))
+}
+
+function setAuthCookie (request, email) {
+  request.cookieAuth.set({ email })
+  console.log(`Logged in user '${email}'.`)
+}
+
+async function clearCache (request, email) {
+  const { magiclinkCache } = request.server.app
+  const emailTokens = await magiclinkCache.get(email)
+  Promise.all(emailTokens.map(async (token) => await magiclinkCache.drop(token)))
+  await magiclinkCache.drop(email)
+}
+
+async function lookupToken (request, token) {
+  const { magiclinkCache } = request.server.app
+  return await magiclinkCache.get(token)
+}
+
 module.exports = [{
   method: 'GET',
   path: '/verify-login',
@@ -20,17 +42,16 @@ module.exports = [{
     handler: async (request, h) => {
       const { email, token } = request.query
 
-      const { magiclinkCache } = request.server.app
-      const tokens = await magiclinkCache.get(email)
-      if (!tokens?.find(x => x === token)) {
+      const cachedEmail = await lookupToken(request, token)
+      if (!cachedEmail || email !== cachedEmail) {
         return h.view('auth/verify-login-failed').code(400)
       }
 
-      const organisation = await getByEmail(email)
-      request.cookieAuth.set({ email })
-      Object.entries(organisation).forEach(([k, v]) => setOrganisation(request, k, v))
-      await magiclinkCache.drop(email)
-      console.log(`Logged in user '${email}'.`)
+      setAuthCookie(request, email)
+
+      await cacheUserData(request, email)
+
+      await clearCache(request, email)
 
       return h.redirect('farmer-apply/org-review')
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",


### PR DESCRIPTION
The fix changes the approach to caching the token, moving away from setting all tokens against the email to extending that to also setting a cache entry for each token.
This removes the potential for a perpetually active (by forever extending the TTL of the email key) set of tokens.
Once a token has been cached, it does not get changed, therefore, allowing them to expire. The collection of tokens against the email will be updated (by adding the new token to it), resetting the email key's TTL. When one key is used, any tokens within the collection for the email will be dropped from cache.

NOTE: Potentially there could be many tokens associated to the email and with them all being run through to be dropped there might be performance hit. However, the use case for this is limited and should the issue arise, there are options to prevent it. For example, rather than the collection of tokens against the email only containing the token, an timestamp could be added so each token is checked to see if it would have expired before attempting to drop it.