### PR TITLE
Bump test coverage

### DIFF
--- a/app/plugins/auth.js
+++ b/app/plugins/auth.js
@@ -27,7 +27,9 @@ module.exports = {
             result.valid = true
           } else {
             const org = await getByEmail(session.email)
-            Object.entries(org).forEach(([k, v]) => setOrganisation(request, k, v))
+            if (org) {
+              Object.entries(org).forEach(([k, v]) => setOrganisation(request, k, v))
+            }
             result.valid = !!org
           }
 

--- a/app/routes/farmer-apply/org-review.js
+++ b/app/routes/farmer-apply/org-review.js
@@ -6,7 +6,6 @@ module.exports = {
   path: '/farmer-apply/org-review',
   options: {
     handler: async (request, h) => {
-      // Take org from cache - should be ok!
       const organisation = session.getOrganisation(request)
       if (!organisation) {
         return boom.notFound()

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,8 @@ module.exports = {
     '<rootDir>/node_modules/',
     '<rootDir>/test-output/',
     '<rootDir>/test/',
-    '<rootDir>/jest.config.js'
+    '<rootDir>/jest.config.js',
+    '<rootDir>/webpack.config.js'
   ],
   modulePathIgnorePatterns: [
     'node_modules'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/auth/login.test.js
+++ b/test/integration/narrow/routes/auth/login.test.js
@@ -12,8 +12,7 @@ describe('Login page test', () => {
   const org = { name: 'my-org' }
 
   beforeAll(async () => {
-    jest.clearAllMocks()
-    jest.resetModules()
+    jest.resetAllMocks()
 
     sendEmail = require('../../../../../app/lib/send-email')
     jest.mock('../../../../../app/lib/send-email')

--- a/test/integration/narrow/routes/auth/login.test.js
+++ b/test/integration/narrow/routes/auth/login.test.js
@@ -26,7 +26,7 @@ describe('Login page test', () => {
   const validEmail = 'dairy@ltd.com'
 
   describe('GET requests to /login', () => {
-    test('GET /login route returns 200', async () => {
+    test('returns 200', async () => {
       const options = {
         method: 'GET',
         url
@@ -40,9 +40,9 @@ describe('Login page test', () => {
       expectLoginPage.hasCorrectContent($)
     })
 
-    test('GET to /login route when already logged in redirects to /farmer-apply/org-review', async () => {
+    test('route when already logged in redirects to org-review', async () => {
       const options = {
-        auth: { credentials: { email: validEmail }, strategy: 'basic', isAuthenticated: true },
+        auth: { credentials: { email: validEmail }, strategy: 'cookie', isAuthenticated: true },
         method: 'GET',
         url
       }
@@ -55,7 +55,7 @@ describe('Login page test', () => {
   })
 
   describe('POST requests to /login', () => {
-    test('POST to /login route returns 400 when request contains empty payload', async () => {
+    test('request contains empty payload', async () => {
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         method: 'POST',
@@ -77,7 +77,7 @@ describe('Login page test', () => {
       { email: 'not-an-email', errorMessage: '"email" must be a valid email' },
       { email: '', errorMessage: '"email" is not allowed to be empty' },
       { email: 'missing@email.com', errorMessage: 'No user found for email \'missing@email.com\'' }
-    ])('POST to /login route returns 400 when request contains incorrect email', async ({ email, errorMessage }) => {
+    ])('route returns 400 when request contains incorrect email - %s', async ({ email, errorMessage }) => {
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         method: 'POST',
@@ -98,7 +98,7 @@ describe('Login page test', () => {
     test.each([
       { crumb: '' },
       { crumb: undefined }
-    ])('POST to /login route returns 403 when request does not contain crumb', async ({ crumb }) => {
+    ])('route returns 403 when request does not contain crumb - $crumb', async ({ crumb }) => {
       const options = {
         method: 'POST',
         url,
@@ -114,7 +114,7 @@ describe('Login page test', () => {
       expect($('.govuk-heading-l').text()).toEqual('403 - Forbidden')
     })
 
-    test('POST to /login route with known email for the first time redirects to email sent page with form filled with email and adds token to cache', async () => {
+    test('route with known email for the first time redirects to email sent page with form filled with email and adds token to cache', async () => {
       getByEmail.mockResolvedValue(org)
       sendEmail.mockResolvedValue(true)
       const crumb = await getCrumbs(global.__SERVER__)
@@ -144,7 +144,7 @@ describe('Login page test', () => {
       cacheSetSpy.mockRestore()
     })
 
-    test('POST to /login route with known email with an existing token redirects to email sent page and adds token to cache', async () => {
+    test('route with known email with an existing token redirects to email sent page and adds token to cache', async () => {
       getByEmail.mockResolvedValue(org)
       sendEmail.mockResolvedValue(true)
       const crumb = await getCrumbs(global.__SERVER__)
@@ -176,7 +176,7 @@ describe('Login page test', () => {
       cacheSetSpy.mockRestore()
     })
 
-    test('POST to /login route with known email sends email', async () => {
+    test('route with known email sends email', async () => {
       getByEmail.mockResolvedValue(org)
       sendEmail.mockResolvedValue(true)
       const crumb = await getCrumbs(global.__SERVER__)
@@ -198,7 +198,7 @@ describe('Login page test', () => {
       )
     })
 
-    test('POST to /login route with known email returns error when problem sending email', async () => {
+    test('route with known email returns error when problem sending email', async () => {
       getByEmail.mockResolvedValue(org)
       sendEmail.mockResolvedValue(false)
       const crumb = await getCrumbs(global.__SERVER__)

--- a/test/integration/narrow/routes/auth/verify-login.test.js
+++ b/test/integration/narrow/routes/auth/verify-login.test.js
@@ -5,8 +5,7 @@ describe('Verify login page test', () => {
   let getByEmail
 
   beforeAll(async () => {
-    jest.clearAllMocks()
-    jest.resetModules()
+    jest.resetAllMocks()
 
     const orgs = require('../../../../../app/api-requests/users')
     getByEmail = orgs.getByEmail

--- a/test/integration/narrow/routes/auth/verify-login.test.js
+++ b/test/integration/narrow/routes/auth/verify-login.test.js
@@ -23,7 +23,7 @@ describe('Verify login page test', () => {
     { email: '' },
     { email: 'not-an-email' },
     { email: 'email@not-on-list.com' }
-  ])('GET /verify-login route returns 400 when request does not include a valid email', async ({ email }) => {
+  ])('GET /verify-login route returns 400 when request does not include a valid email - $email', async ({ email }) => {
     const options = {
       method: 'GET',
       url: `${url}?email=${email}&token=${validToken}`
@@ -41,7 +41,7 @@ describe('Verify login page test', () => {
     { token: '' },
     { token: 'not-a-uuid' },
     { token: validToken }
-  ])('GET /verify-login route returns 400 when request does not include a valid token', async ({ token }) => {
+  ])('GET /verify-login route returns 400 when request does not include a valid token - $token', async ({ token }) => {
     const options = {
       method: 'GET',
       url: `${url}?email=${validEmail}&token=${token}`

--- a/test/integration/narrow/routes/farmer-apply/cattle-type.test.js
+++ b/test/integration/narrow/routes/farmer-apply/cattle-type.test.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 
 describe('Cattle Type test', () => {
   test('GET /farmer-apply/cattle-type route returns 200', async () => {

--- a/test/integration/narrow/routes/farmer-apply/cattle-type.test.js
+++ b/test/integration/narrow/routes/farmer-apply/cattle-type.test.js
@@ -2,23 +2,37 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
-
 describe('Cattle Type test', () => {
-  test('GET /farmer-apply/cattle-type route returns 200', async () => {
+  const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
+  const url = '/farmer-apply/cattle-type'
+
+  test(`GET ${url} route returns 200`, async () => {
     const options = {
       method: 'GET',
-      url: '/farmer-apply/cattle-type',
+      url,
       auth
     }
     const res = await global.__SERVER__.inject(options)
     expect(res.statusCode).toBe(200)
   })
-  test('POST /farmer-apply/cattle-type route returns 302', async () => {
+
+  test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const options = {
+      method: 'GET',
+      url
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
+  })
+
+  test(`POST ${url} route returns 302`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/cattle-type',
+      url,
       payload: { crumb, 'cattle-type': 'beef' },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -27,11 +41,12 @@ describe('Cattle Type test', () => {
     expect(res.statusCode).toBe(302)
     expect(res.headers.location).toEqual('/farmer-apply/sheep')
   })
-  test('POST /farmer-apply/cattle-type route returns Error', async () => {
+
+  test(`POST ${url} route returns Error`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/cattle-type',
+      url,
       payload: { crumb, 'cattle-type': 'xyz' },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -40,5 +55,20 @@ describe('Cattle Type test', () => {
     const $ = cheerio.load(res.payload)
     expect($('p.govuk-error-message').text()).toMatch('Select the type of cattle that you keep')
     expect(res.statusCode).toBe(200)
+  })
+
+  test(`POST ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const crumb = await getCrumbs(global.__SERVER__)
+    const options = {
+      method: 'POST',
+      url,
+      payload: { crumb, 'cattle-type': 'xyz' },
+      headers: { cookie: `crumb=${crumb}` }
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/cattle.test.js
+++ b/test/integration/narrow/routes/farmer-apply/cattle.test.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 
 describe('Cattle test', () => {
   test('GET /farmer-apply/cattle route returns 200', async () => {

--- a/test/integration/narrow/routes/farmer-apply/cattle.test.js
+++ b/test/integration/narrow/routes/farmer-apply/cattle.test.js
@@ -2,23 +2,37 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
-
 describe('Cattle test', () => {
-  test('GET /farmer-apply/cattle route returns 200', async () => {
+  const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
+  const url = '/farmer-apply/cattle'
+
+  test(`GET ${url} route returns 200`, async () => {
     const options = {
       method: 'GET',
-      url: '/farmer-apply/cattle',
+      url,
       auth
     }
     const res = await global.__SERVER__.inject(options)
     expect(res.statusCode).toBe(200)
   })
-  test('POST /farmer-apply/cattle route returns 302', async () => {
+
+  test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const options = {
+      method: 'GET',
+      url
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
+  })
+
+  test(`POST ${url} route returns 302`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/cattle',
+      url,
       payload: { crumb, cattle: 'yes' },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -27,11 +41,12 @@ describe('Cattle test', () => {
     expect(res.statusCode).toBe(302)
     expect(res.headers.location).toEqual('/farmer-apply/cattle-type')
   })
-  test('POST /farmer-apply/cattle redirects to sheep when no cattle selected', async () => {
+
+  test(`POST ${url} redirects to sheep when no cattle selected`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/cattle',
+      url,
       payload: { crumb, cattle: 'no' },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -40,11 +55,12 @@ describe('Cattle test', () => {
     expect(res.statusCode).toBe(302)
     expect(res.headers.location).toEqual('/farmer-apply/sheep')
   })
-  test('POST /farmer-apply/cattle route returns Error', async () => {
+
+  test(`POST ${url} route returns Error`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/cattle',
+      url,
       payload: { crumb, cattle: null },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -53,5 +69,20 @@ describe('Cattle test', () => {
     const $ = cheerio.load(res.payload)
     expect($('p.govuk-error-message').text()).toMatch('Select yes if you keep more than 10 cattle')
     expect(res.statusCode).toBe(200)
+  })
+
+  test(`POST ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const crumb = await getCrumbs(global.__SERVER__)
+    const options = {
+      method: 'POST',
+      url,
+      payload: { crumb, cattle: 'no' },
+      headers: { cookie: `crumb=${crumb}` }
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/check-answers.test.js
+++ b/test/integration/narrow/routes/farmer-apply/check-answers.test.js
@@ -1,6 +1,6 @@
 const cheerio = require('cheerio')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 const varListTemplate = {
   cattle: 'yes',
   pig: 'yes',

--- a/test/integration/narrow/routes/farmer-apply/check-answers.test.js
+++ b/test/integration/narrow/routes/farmer-apply/check-answers.test.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const varListTemplate = {
   cattle: 'yes',
-  pig: 'yes',
+  pigs: 'yes',
   sheep: 'yes',
   cattleType: 'both'
 }
@@ -33,14 +33,16 @@ describe('Check Answers test', () => {
       url,
       auth
     }
+
     const res = await global.__SERVER__.inject(options)
+
     expect(res.statusCode).toBe(200)
   })
 
-  test(`GET ${url} route returns 302`, async () => {
+  test(`GET ${url} route returns 302 when there is no eligible livestock`, async () => {
     varList = {
       cattle: 'no',
-      pig: 'no',
+      pigs: 'no',
       sheep: 'no',
       cattleType: 'both'
     }
@@ -49,27 +51,62 @@ describe('Check Answers test', () => {
       url,
       auth
     }
+
     const res = await global.__SERVER__.inject(options)
+
     expect(res.statusCode).toBe(302)
     expect(res.headers.location).toEqual('/farmer-apply/not-eligible')
   })
 
-  test(`GET ${url} route returns 302`, async () => {
+  test.each([
+    { cattleType: 'beef', text: 'Beef' },
+    { cattleType: 'both', text: 'Beef and Dairy' },
+    { cattleType: 'dairy', text: 'Dairy' }
+  ])(`GET ${url} route shows beef and dairy option when cattleType is both - %s`, async ({ cattleType, text }) => {
     varList = {
       cattle: 'yes',
-      pig: 'no',
+      pigs: 'no',
       sheep: 'no',
-      cattleType: 'both'
+      cattleType
     }
     const options = {
       method: 'GET',
       url,
       auth
     }
+
     const res = await global.__SERVER__.inject(options)
+
     expect(res.statusCode).toBe(200)
     const $ = cheerio.load(res.payload)
-    expect($('.govuk-summary-list').text()).toContain('Beef and Dairy')
+    expect($('.govuk-summary-list__row').length).toEqual(2)
+    expect($('.govuk-summary-list__key').eq(0).text()).toMatch('Livestock')
+    expect($('.govuk-summary-list__value').eq(0).text()).toMatch('More than 10 cattle')
+    expect($('.govuk-summary-list__key').eq(1).text()).toMatch('Cattle type')
+    expect($('.govuk-summary-list__value').eq(1).text()).toMatch(text)
+  })
+
+  test(`GET ${url} route does not show beef and dairy option when cattle is not selected is both`, async () => {
+    varList = {
+      cattle: 'no',
+      pigs: 'yes',
+      sheep: 'yes',
+      cattleType: ''
+    }
+    const options = {
+      method: 'GET',
+      url,
+      auth
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(200)
+    const $ = cheerio.load(res.payload)
+    expect($('.govuk-summary-list__row').length).toEqual(1)
+    expect($('.govuk-summary-list__key').eq(0).text()).toMatch('Livestock')
+    expect($('.govuk-summary-list__value').eq(0).text()).toMatch('More than 50 pigs')
+    expect($('.govuk-summary-list__value').eq(0).text()).toMatch('More than 20 sheep')
   })
 
   test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {

--- a/test/integration/narrow/routes/farmer-apply/confirmation.test.js
+++ b/test/integration/narrow/routes/farmer-apply/confirmation.test.js
@@ -17,14 +17,17 @@ const mockSession = {
 jest.mock('../../../../../app/session', () => mockSession)
 
 describe('Confirmation test', () => {
+  const url = '/farmer-apply/confirmation'
+
   afterEach(() => {
     jest.resetAllMocks()
   })
-  test('POST /farmer-apply/confirmation route returns 200', async () => {
+
+  test(`POST ${url} route returns 200`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/confirmation',
+      url,
       payload: { crumb },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -33,5 +36,20 @@ describe('Confirmation test', () => {
     expect(res.statusCode).toBe(200)
     const $ = cheerio.load(res.payload)
     expect($('h1').text()).toMatch('Application complete')
+  })
+
+  test(`POST ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const crumb = await getCrumbs(global.__SERVER__)
+    const options = {
+      method: 'POST',
+      url,
+      payload: { crumb },
+      headers: { cookie: `crumb=${crumb}` }
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/confirmation.test.js
+++ b/test/integration/narrow/routes/farmer-apply/confirmation.test.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 
 jest.mock('../../../../../app/lib/send-email', () => () => {
   return jest.fn().mockReturnValueOnce(true)

--- a/test/integration/narrow/routes/farmer-apply/declaration.test.js
+++ b/test/integration/narrow/routes/farmer-apply/declaration.test.js
@@ -1,6 +1,6 @@
 const cheerio = require('cheerio')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 
 describe('Declaration test', () => {
   test('GET /farmer-apply/declaration route returns 200', async () => {

--- a/test/integration/narrow/routes/farmer-apply/declaration.test.js
+++ b/test/integration/narrow/routes/farmer-apply/declaration.test.js
@@ -1,17 +1,30 @@
 const cheerio = require('cheerio')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
-
 describe('Declaration test', () => {
-  test('GET /farmer-apply/declaration route returns 200', async () => {
+  const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
+  const url = '/farmer-apply/declaration'
+
+  test(`GET ${url} route returns 200`, async () => {
     const options = {
       method: 'GET',
-      url: '/farmer-apply/declaration',
+      url,
       auth
     }
     const res = await global.__SERVER__.inject(options)
     expect(res.statusCode).toBe(200)
     const $ = cheerio.load(res.payload)
     expect($('h1.govuk-heading-l').text()).toEqual('Declaration')
+  })
+
+  test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const options = {
+      method: 'GET',
+      url
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/not-eligible.test.js
+++ b/test/integration/narrow/routes/farmer-apply/not-eligible.test.js
@@ -1,0 +1,19 @@
+const cheerio = require('cheerio')
+const expectPhaseBanner = require('../../../../utils/phase-banner-expect')
+
+describe('Not eligible page test', () => {
+  test('GET /farmer-apply/not-eligible route returns 200', async () => {
+    const options = {
+      auth: { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' },
+      method: 'GET',
+      url: '/farmer-apply/not-eligible'
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(200)
+    const $ = cheerio.load(res.payload)
+    expect($('.govuk-heading-l').text()).toEqual('You are not eligible to apply')
+    expectPhaseBanner.ok($)
+  })
+})

--- a/test/integration/narrow/routes/farmer-apply/not-eligible.test.js
+++ b/test/integration/narrow/routes/farmer-apply/not-eligible.test.js
@@ -2,11 +2,13 @@ const cheerio = require('cheerio')
 const expectPhaseBanner = require('../../../../utils/phase-banner-expect')
 
 describe('Not eligible page test', () => {
-  test('GET /farmer-apply/not-eligible route returns 200', async () => {
+  const url = '/farmer-apply/not-eligible'
+
+  test(`GET ${url} route when logged in returns 200`, async () => {
     const options = {
       auth: { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' },
       method: 'GET',
-      url: '/farmer-apply/not-eligible'
+      url
     }
 
     const res = await global.__SERVER__.inject(options)
@@ -15,5 +17,17 @@ describe('Not eligible page test', () => {
     const $ = cheerio.load(res.payload)
     expect($('.govuk-heading-l').text()).toEqual('You are not eligible to apply')
     expectPhaseBanner.ok($)
+  })
+
+  test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const options = {
+      method: 'GET',
+      url
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/org-review.test.js
+++ b/test/integration/narrow/routes/farmer-apply/org-review.test.js
@@ -7,8 +7,7 @@ describe('Org review page test', () => {
 
   describe(`GET ${url} route when logged in`, () => {
     beforeAll(async () => {
-      jest.clearAllMocks()
-      jest.resetModules()
+      jest.resetAllMocks()
 
       session = require('../../../../../app/session')
       jest.mock('../../../../../app/session')

--- a/test/integration/narrow/routes/farmer-apply/org-review.test.js
+++ b/test/integration/narrow/routes/farmer-apply/org-review.test.js
@@ -1,0 +1,80 @@
+const cheerio = require('cheerio')
+const expectPhaseBanner = require('../../../../utils/phase-banner-expect')
+
+describe('Org review page test', () => {
+  let session
+  const url = '/farmer-apply/org-review'
+
+  describe(`GET ${url} route when logged in`, () => {
+    beforeAll(async () => {
+      jest.clearAllMocks()
+      jest.resetModules()
+
+      session = require('../../../../../app/session')
+      jest.mock('../../../../../app/session')
+    })
+
+    test('returns 200', async () => {
+      const org = {
+        address: ' org-address-here',
+        cph: '11/222/3333',
+        email: 'org@test.com',
+        name: 'org-name',
+        sbi: '123456789'
+      }
+      session.getOrganisation.mockReturnValue(org)
+      const options = {
+        auth: { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' },
+        method: 'GET',
+        url
+      }
+
+      const res = await global.__SERVER__.inject(options)
+
+      expect(res.statusCode).toBe(200)
+      const $ = cheerio.load(res.payload)
+      expect($('.govuk-heading-l').text()).toEqual('Health and welfare review funding for this organisation')
+      expect($('.govuk-heading-m').text()).toEqual(org.name)
+      const keys = $('.govuk-summary-list__key')
+      const values = $('.govuk-summary-list__value')
+      expect(keys.eq(0).text()).toMatch('SBI number')
+      expect(values.eq(0).text()).toMatch(org.sbi)
+      expect(keys.eq(1).text()).toMatch('CPH number')
+      expect(values.eq(1).text()).toMatch(org.cph)
+      expect(keys.eq(2).text()).toMatch('Address')
+      expect(values.eq(2).text()).toMatch(org.address)
+      expect(keys.eq(3).text()).toMatch('Contact email address')
+      expect(values.eq(3).text()).toMatch(org.email)
+      expectPhaseBanner.ok($)
+    })
+
+    test('returns 404 when no organisation is found', async () => {
+      session.getOrganisation.mockReturnValue(undefined)
+      const options = {
+        auth: { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' },
+        method: 'GET',
+        url
+      }
+
+      const res = await global.__SERVER__.inject(options)
+
+      expect(res.statusCode).toBe(404)
+      const $ = cheerio.load(res.payload)
+      expect($('.govuk-heading-l').text()).toEqual('404 - Not Found')
+    })
+  })
+
+  describe(`GET ${url} route when not logged in`, () => {
+    test('redirects to /login with last page as next param', async () => {
+      const options = {
+        method: 'GET',
+        url
+      }
+
+      const res = await global.__SERVER__.inject(options)
+
+      expect(res.statusCode).toBe(302)
+      expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
+    })
+  })
+})

--- a/test/integration/narrow/routes/farmer-apply/pigs.test.js
+++ b/test/integration/narrow/routes/farmer-apply/pigs.test.js
@@ -2,23 +2,37 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
-
 describe('Pigs test', () => {
-  test('GET /farmer-apply/pigs route returns 200', async () => {
+  const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
+  const url = '/farmer-apply/pigs'
+
+  test(`GET ${url} route returns 200`, async () => {
     const options = {
       method: 'GET',
-      url: '/farmer-apply/pigs',
+      url,
       auth
     }
     const res = await global.__SERVER__.inject(options)
     expect(res.statusCode).toBe(200)
   })
-  test('POST /farmer-apply/pigs route returns 302', async () => {
+
+  test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const options = {
+      method: 'GET',
+      url
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
+  })
+
+  test(`POST ${url} route returns 302`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/pigs',
+      url,
       payload: { crumb, pigs: 'yes' },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -27,11 +41,12 @@ describe('Pigs test', () => {
     expect(res.statusCode).toBe(302)
     expect(res.headers.location).toEqual('/farmer-apply/check-answers')
   })
-  test('POST /farmer-apply/pigs route returns Error', async () => {
+
+  test(`POST ${url} route returns Error`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/pigs',
+      url,
       payload: { crumb, pigs: null },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -40,5 +55,20 @@ describe('Pigs test', () => {
     const $ = cheerio.load(res.payload)
     expect($('p.govuk-error-message').text()).toMatch('Select yes if you keep more than 50 pigs')
     expect(res.statusCode).toBe(200)
+  })
+
+  test(`POST ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const crumb = await getCrumbs(global.__SERVER__)
+    const options = {
+      method: 'POST',
+      url,
+      payload: { crumb, pigs: 'no' },
+      headers: { cookie: `crumb=${crumb}` }
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/pigs.test.js
+++ b/test/integration/narrow/routes/farmer-apply/pigs.test.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 
 describe('Pigs test', () => {
   test('GET /farmer-apply/pigs route returns 200', async () => {

--- a/test/integration/narrow/routes/farmer-apply/sheep.test.js
+++ b/test/integration/narrow/routes/farmer-apply/sheep.test.js
@@ -2,23 +2,37 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
-
 describe('Sheep test', () => {
-  test('GET /farmer-apply/sheep route returns 200', async () => {
+  const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
+  const url = '/farmer-apply/sheep'
+
+  test(`GET ${url} route returns 200`, async () => {
     const options = {
       method: 'GET',
-      url: '/farmer-apply/sheep',
+      url,
       auth
     }
     const res = await global.__SERVER__.inject(options)
     expect(res.statusCode).toBe(200)
   })
-  test('POST /farmer-apply/sheep route returns 302', async () => {
+
+  test(`GET ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const options = {
+      method: 'GET',
+      url
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
+  })
+
+  test(`POST ${url} route returns 302`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/sheep',
+      url,
       payload: { crumb, sheep: 'yes' },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -27,11 +41,12 @@ describe('Sheep test', () => {
     expect(res.statusCode).toBe(302)
     expect(res.headers.location).toEqual('/farmer-apply/pigs')
   })
-  test('POST /farmer-apply/sheep route returns Error', async () => {
+
+  test(`POST ${url} route returns Error`, async () => {
     const crumb = await getCrumbs(global.__SERVER__)
     const options = {
       method: 'POST',
-      url: '/farmer-apply/sheep',
+      url,
       payload: { crumb, sheep: null },
       auth,
       headers: { cookie: `crumb=${crumb}` }
@@ -40,5 +55,20 @@ describe('Sheep test', () => {
     const $ = cheerio.load(res.payload)
     expect($('p.govuk-error-message').text()).toMatch('Select yes if you keep more than 20 sheep')
     expect(res.statusCode).toBe(200)
+  })
+
+  test(`POST ${url} route when not logged in redirects to /login with last page as next param`, async () => {
+    const crumb = await getCrumbs(global.__SERVER__)
+    const options = {
+      method: 'POST',
+      url,
+      payload: { crumb, sheep: 'no' },
+      headers: { cookie: `crumb=${crumb}` }
+    }
+
+    const res = await global.__SERVER__.inject(options)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toEqual(`/login?next=${encodeURIComponent(url)}`)
   })
 })

--- a/test/integration/narrow/routes/farmer-apply/sheep.test.js
+++ b/test/integration/narrow/routes/farmer-apply/sheep.test.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const getCrumbs = require('../../../../utils/get-crumbs')
 
-const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'basic' }
+const auth = { credentials: { reference: '1111', sbi: '111111111' }, strategy: 'cookie' }
 
 describe('Sheep test', () => {
   test('GET /farmer-apply/sheep route returns 200', async () => {

--- a/test/integration/narrow/routes/farmer-apply/sheep.test.js
+++ b/test/integration/narrow/routes/farmer-apply/sheep.test.js
@@ -10,13 +10,20 @@ describe('Sheep test', () => {
     const session = require('../../../../../app/session')
     jest.mock('../../../../../app/session')
 
-    test('returns 200 with backlink to cattle when no answers exist for cattle', async () => {
+    afterAll(() => {
+      jest.resetAllMocks()
+    })
+
+    test.each([
+      { answer: 'no' },
+      { answer: undefined }
+    ])('returns 200 with backlink to cattle when no answers exist for cattle - %s', async ({ answer }) => {
       const options = {
         method: 'GET',
         url,
         auth
       }
-      session.getApplication.mockReturnValue(undefined)
+      session.getApplication.mockReturnValue(answer)
 
       const res = await global.__SERVER__.inject(options)
 

--- a/test/unit/app-insights.test.js
+++ b/test/unit/app-insights.test.js
@@ -1,0 +1,59 @@
+describe('Application Insights', () => {
+  const appInsights = require('applicationinsights')
+  jest.mock('applicationinsights')
+
+  const startMock = jest.fn()
+  const setupMock = jest.fn(() => {
+    return {
+      start: startMock
+    }
+  })
+  appInsights.setup = setupMock
+  const cloudRoleTag = 'cloudRoleTag'
+  const tags = {}
+  appInsights.defaultClient = {
+    context: {
+      keys: {
+        cloudRole: cloudRoleTag
+      },
+      tags
+    }
+  }
+
+  const consoleLogSpy = jest.spyOn(console, 'log')
+
+  const appInsightsKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+
+  beforeEach(() => {
+    delete process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    process.env.APPINSIGHTS_INSTRUMENTATIONKEY = appInsightsKey
+  })
+
+  test('is started when env var exists', () => {
+    const appName = 'test-app'
+    process.env.APPINSIGHTS_CLOUDROLE = appName
+    process.env.APPINSIGHTS_INSTRUMENTATIONKEY = 'something'
+    const insights = require('../../app/insights')
+
+    insights.setup()
+
+    expect(setupMock).toHaveBeenCalledTimes(1)
+    expect(startMock).toHaveBeenCalledTimes(1)
+    expect(tags[cloudRoleTag]).toEqual(appName)
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1)
+    expect(consoleLogSpy).toHaveBeenCalledWith('App Insights Running')
+  })
+
+  test('logs not running when env var does not exist', () => {
+    const insights = require('../../app/insights')
+
+    insights.setup()
+
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1)
+    expect(consoleLogSpy).toHaveBeenCalledWith('App Insights Not Running!')
+  })
+})

--- a/test/unit/app/api-requests/users.test.js
+++ b/test/unit/app/api-requests/users.test.js
@@ -25,7 +25,7 @@ describe('Get users', () => {
   test.each([
     { fileContent: null },
     { fileContent: undefined }
-  ])('return undefined when blob content is null or undefined', async ({ fileContent }) => {
+  ])('return undefined when blob content is $fileContent', async ({ fileContent }) => {
     downloadBlobMock.mockResolvedValue(fileContent)
 
     const res = await getByEmail('email')

--- a/test/unit/app/api-requests/users.test.js
+++ b/test/unit/app/api-requests/users.test.js
@@ -5,7 +5,7 @@ describe('Get users', () => {
   let getByEmail
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
     jest.resetModules()
 
     downloadBlobMock = require('../../../../app/lib/download-blob')

--- a/test/unit/app/lib/download-blob.test.js
+++ b/test/unit/app/lib/download-blob.test.js
@@ -6,7 +6,7 @@ describe('Download blob tests', () => {
   const file = 'file'
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
     jest.resetModules()
 
     const storageBlobMock = require('@azure/storage-blob')

--- a/test/unit/app/plugins/auth.test.js
+++ b/test/unit/app/plugins/auth.test.js
@@ -1,0 +1,62 @@
+const { v4: uuid } = require('uuid')
+
+describe('Auth plugin test', () => {
+  let getByEmail
+  let session
+  const org = { name: 'my-org' }
+
+  beforeAll(async () => {
+    jest.clearAllMocks()
+    jest.resetModules()
+
+    session = require('../../../../app/session')
+    jest.mock('../../../../app/session')
+    const orgs = require('../../../../app/api-requests/users')
+    getByEmail = orgs.getByEmail
+    jest.mock('../../../../app/api-requests/users')
+  })
+
+  const url = '/login'
+  const validEmail = 'dairy@ltd.com'
+
+  describe('GET requests to /login', () => {
+    async function login () {
+      const email = uuid() + validEmail
+      const token = uuid()
+      const options = {
+        method: 'GET',
+        url: `/verify-login?email=${email}&token=${token}`
+      }
+
+      await global.__SERVER__.app.magiclinkCache.set(email, [token])
+      await global.__SERVER__.app.magiclinkCache.set(token, email)
+
+      return global.__SERVER__.inject(options)
+    }
+
+    test('when logged in with nothing in session loads data into session and then uses that session data', async () => {
+      const loginResponse = await login()
+
+      const cookieHeaders = loginResponse.headers['set-cookie'].map(x => x.split('; ')[0]).join('; ')
+
+      const options = {
+        method: 'GET',
+        url,
+        headers: { cookie: cookieHeaders }
+      }
+      getByEmail.mockResolvedValue(org)
+
+      const res = await global.__SERVER__.inject(options)
+
+      expect(res.statusCode).toBe(302)
+      expect(res.headers.location).toEqual('farmer-apply/org-review')
+      expect(session.setOrganisation).toHaveBeenCalledTimes(1)
+      expect(session.setOrganisation).toHaveBeenCalledWith(res.request, 'name', org.name)
+
+      const resTwo = await global.__SERVER__.inject(options)
+
+      expect(resTwo.statusCode).toBe(302)
+      expect(resTwo.headers.location).toEqual('farmer-apply/org-review')
+    })
+  })
+})

--- a/test/unit/app/plugins/auth.test.js
+++ b/test/unit/app/plugins/auth.test.js
@@ -6,8 +6,7 @@ describe('Auth plugin test', () => {
   const org = { name: 'my-org' }
 
   beforeAll(async () => {
-    jest.clearAllMocks()
-    jest.resetModules()
+    jest.resetAllMocks()
 
     session = require('../../../../app/session')
     jest.mock('../../../../app/session')

--- a/test/unit/app/plugins/crumb.test.js
+++ b/test/unit/app/plugins/crumb.test.js
@@ -1,0 +1,8 @@
+const crumbPlugin = require('../../../../app/plugins/crumb')
+
+describe('crumb plugin', () => {
+  test('is correctly configured', () => {
+    expect(crumbPlugin.options.cookieOptions).toHaveProperty('isSecure')
+    expect(crumbPlugin.options.cookieOptions.isSecure).toEqual(false)
+  })
+})


### PR DESCRIPTION
Changes revolve around increasing test coverage, including routes that previously had no tests:
* `not-eligible`
* `org-review`
Extending test coverage for routes and plugins:
* `check-answers` route
* `cattle` & `cattle-type` routes
* `confirmation` & `declaration` routes
* `pig` & `sheep` routes
* `auth` and `crumb` plugins
* accessing routes when not authenticated