### PR TITLE
feat: validate visit date against application date

### DIFF
--- a/app/config/visit-date.js
+++ b/app/config/visit-date.js
@@ -7,6 +7,5 @@ module.exports = {
     day: `${labelPrefix}day`,
     month: `${labelPrefix}month`,
     year: `${labelPrefix}year`
-  },
-  startDateString: '2022-04-01'
+  }
 }

--- a/app/lib/email/send-magic-link-email.js
+++ b/app/lib/email/send-magic-link-email.js
@@ -2,14 +2,14 @@ const { v4: uuid } = require('uuid')
 const sendEmail = require('./send-email')
 const { serviceUri } = require('../../config')
 
-async function createAndCacheToken (request, email, redirectTo, userType) {
+async function createAndCacheToken (request, email, redirectTo, userType, data) {
   const { magiclinkCache } = request.server.app
 
   const token = uuid()
   const tokens = await magiclinkCache.get(email) ?? []
   tokens.push(token)
   await magiclinkCache.set(email, tokens)
-  await magiclinkCache.set(token, { email, redirectTo, userType })
+  await magiclinkCache.set(token, { email, redirectTo, userType, data })
   return token
 }
 
@@ -27,11 +27,12 @@ async function createAndCacheToken (request, email, redirectTo, userType) {
  * variable set for personalisation.
  * @param {string} redirectTo the route to redirect the user to once logged in.
  * @param {string} userType the type of user.
+ * @param {object} data object containing data to cache.
  * @return {boolean} value indicating whether the email send was successful or
  * not.
  */
-module.exports = async (request, email, templateId, redirectTo, userType) => {
-  const token = await createAndCacheToken(request, email, redirectTo, userType)
+module.exports = async (request, email, templateId, redirectTo, userType, data) => {
+  const token = await createAndCacheToken(request, email, redirectTo, userType, data)
 
   return sendEmail(templateId, email, {
     personalisation: { magiclink: `${serviceUri}/verify-login?token=${token}&email=${email}` },

--- a/app/lib/error-messages.js
+++ b/app/lib/error-messages.js
@@ -1,5 +1,3 @@
-const { startDateString } = require('../config/visit-date')
-
 module.exports = {
   email: {
     enterEmail: 'Enter an email address',
@@ -25,7 +23,7 @@ module.exports = {
     emptyValues: (val1, val2) => `Visit date must include a ${val1}${val2 ? ' and a ' + val2 : ''}`,
     enterDate: 'Enter the date of the visit',
     realDate: 'Visit date must be a real date',
-    startDateOrAfter: () => `Visit date must be the same as or after ${new Date(startDateString).toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}`,
+    startDateOrAfter: (createdAt) => `Visit date must be the same as or after ${new Date(createdAt).toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })} when the application was created`,
     todayOrPast: 'Visit date must be today or in the past'
   }
 }

--- a/app/lib/visit-date/date-input-errors.js
+++ b/app/lib/visit-date/date-input-errors.js
@@ -1,5 +1,5 @@
 const createItems = require('./date-input-items')
-const { isDateInFutureOrBeforeStartDate } = require('./validation')
+const { isDateInFutureOrBeforeFirstValidDate } = require('./validation')
 const { inputErrorClass } = require('../../config/visit-date')
 const { visitDate: errorMessages } = require('../../../app/lib/error-messages')
 
@@ -16,7 +16,18 @@ function getEmptyValuesMessage (emptyValues) {
   return text
 }
 
-module.exports = (errorDetails, payload) => {
+/**
+ * Generates the text input items for a govukDateInput along with an error
+ * message, based on the reason why the validation failed.
+ * Returns an object containing two properties, `errorMessage` (an object
+ * containing a `text` property) and `items` (an array of input items).
+ *
+ * @param {object} errorDetails Joi result object containing details of the
+ * error the payload failed for.
+ * @param {object} payload from the request that failed the validation.
+ * @param {string} firstValidDate Date string representing first valid date.
+ */
+module.exports = (errorDetails, payload, firstValidDate) => {
   const items = createItems(payload, false)
 
   const emptyValues = []
@@ -30,7 +41,7 @@ module.exports = (errorDetails, payload) => {
 
   let text = getEmptyValuesMessage(emptyValues)
   if (!text) {
-    const { isDateValid, errorMessage } = isDateInFutureOrBeforeStartDate(payload)
+    const { isDateValid, errorMessage } = isDateInFutureOrBeforeFirstValidDate(payload, firstValidDate)
     if (isDateValid) {
       text = errorMessages.realDate
     } else {

--- a/app/lib/visit-date/validation.js
+++ b/app/lib/visit-date/validation.js
@@ -1,28 +1,51 @@
-const { labels, startDateString } = require('../../config/visit-date')
+const { labels } = require('../../config/visit-date')
 const { visitDate: errorMessages } = require('../../../app/lib/error-messages')
 
-function isDateInFuture (inputDate) {
-  return inputDate > Date.now()
-}
-
-function isDateBeforeStartDate (inputDate) {
-  const startDate = new Date(startDateString)
-  return inputDate < startDate
-}
-
-function isDateInFutureOrBeforeStartDate (payload) {
+function getDateFromPayload (payload) {
   const day = payload[labels.day]
   const month = payload[labels.month]
   const year = payload[labels.year]
-  const inputDate = new Date(year, month - 1, day)
+  return new Date(year, month - 1, day)
+}
 
-  const futureDate = isDateInFuture(inputDate)
-  if (futureDate || isDateBeforeStartDate(inputDate)) {
+function isDateInFuture (date) {
+  return date > new Date()
+}
+
+/**
+ * Compares one date to another to check if it is before.
+ *
+ * @param {Date} date.
+ * @param {Date} dateToCompare against.
+ *
+ * @return {boolean} result of comparison.
+ */
+function isDateBefore (date, dateToCompare) {
+  const cloneDate = new Date(dateToCompare)
+  cloneDate.setDate(cloneDate.getDate() - 1)
+  return date < cloneDate
+}
+
+/**
+ * Checks if the date in `payload` is in the future or before `dateToCompare`.
+ *
+ * @param {object} payload containing `day`, `month` & `year`.
+ * @param {Date} dateToCompare the date to compare against.
+ *
+ * @return {object} containing boolean `isDateValid` property and an optional
+ * `errorMessage` property object containing `text` - a string representing the
+  * error message.
+ */
+function isDateInFutureOrBeforeFirstValidDate (payload, dateToCompare) {
+  const date = getDateFromPayload(payload)
+
+  const futureDate = isDateInFuture(date)
+  if (futureDate || isDateBefore(date, dateToCompare)) {
     return {
       errorMessage: {
-        text: futureDate ? errorMessages.todayOrPast : errorMessages.startDateOrAfter(),
-        isDateValid: false
-      }
+        text: futureDate ? errorMessages.todayOrPast : errorMessages.startDateOrAfter(dateToCompare)
+      },
+      isDateValid: false
     }
   }
   return {
@@ -31,5 +54,5 @@ function isDateInFutureOrBeforeStartDate (payload) {
 }
 
 module.exports = {
-  isDateInFutureOrBeforeStartDate
+  isDateInFutureOrBeforeFirstValidDate
 }

--- a/app/messaging/application/index.js
+++ b/app/messaging/application/index.js
@@ -1,0 +1,11 @@
+const { sendMessage, receiveMessage } = require('../')
+const { applicationRequestQueue, fetchApplicationRequestMsgType, applicationResponseQueue } = require('../../config')
+
+function getApplication (applicationReference, sessionId) {
+  sendMessage({ applicationReference, sessionId }, fetchApplicationRequestMsgType, applicationRequestQueue, { sessionId })
+  return receiveMessage(sessionId, applicationResponseQueue)
+}
+
+module.exports = {
+  getApplication
+}

--- a/app/routes/farmer-apply/login.js
+++ b/app/routes/farmer-apply/login.js
@@ -1,9 +1,7 @@
 const boom = require('@hapi/boom')
 const Joi = require('joi')
 const { getByEmail } = require('../../api-requests/users')
-const { notify: { templateIdFarmerLogin } } = require('../../config')
-const { farmer } = require('../../config/user-types')
-const sendMagicLinkEmail = require('../../lib/email/send-magic-link-email')
+const { sendFarmerLoginMagicLinkEmail } = require('../../lib/email/send-magic-link-email')
 const { email: emailValidation } = require('../../../app/lib/validation/email')
 
 module.exports = [{
@@ -48,7 +46,7 @@ module.exports = [{
         return h.view('auth/magic-login', { ...request.payload, errorMessage: { text: `No user found with email address "${email}"` } }).code(400).takeover()
       }
 
-      const result = await sendMagicLinkEmail(request, email, templateIdFarmerLogin, 'farmer-apply/org-review', farmer)
+      const result = await sendFarmerLoginMagicLinkEmail(request, email)
 
       if (!result) {
         return boom.internal()

--- a/app/routes/vet/email.js
+++ b/app/routes/vet/email.js
@@ -34,7 +34,9 @@ module.exports = [{
       const { email } = request.payload
       session.setVetSignup(request, emailKey, email)
 
-      const result = await sendMagicLinkEmail(request, email, templateIdVetLogin, 'vet/visit-date', vet)
+      const data = session.getVetSignup(request)
+      // TODO: potentially refactor to a single function for vet magiclink and another one for farmer
+      const result = await sendMagicLinkEmail(request, email, templateIdVetLogin, 'vet/visit-date', vet, data)
 
       if (!result) {
         return boom.internal()

--- a/app/routes/vet/email.js
+++ b/app/routes/vet/email.js
@@ -1,8 +1,6 @@
 const boom = require('@hapi/boom')
 const Joi = require('joi')
-const { notify: { templateIdVetLogin } } = require('../../config')
-const { vet } = require('../../config/user-types')
-const sendMagicLinkEmail = require('../../lib/email/send-magic-link-email')
+const { sendVetMagicLinkEmail } = require('../../lib/email/send-magic-link-email')
 const session = require('../../session')
 const { vetSignup: { email: emailKey } } = require('../../session/keys')
 const { email: emailValidation } = require('../../../app/lib/validation/email')
@@ -35,8 +33,7 @@ module.exports = [{
       session.setVetSignup(request, emailKey, email)
 
       const data = session.getVetSignup(request)
-      // TODO: potentially refactor to a single function for vet magiclink and another one for farmer
-      const result = await sendMagicLinkEmail(request, email, templateIdVetLogin, 'vet/visit-date', vet, data)
+      const result = await sendVetMagicLinkEmail(request, email, data)
 
       if (!result) {
         return boom.internal()

--- a/app/routes/vet/reference.js
+++ b/app/routes/vet/reference.js
@@ -35,7 +35,6 @@ module.exports = [{
     },
     handler: async (request, h) => {
       const { applicationReference } = request.payload
-      // TODO: Send request to application to check it is valid
       const application = await getApplication(applicationReference, request.yar.id)
 
       if (!application) {

--- a/app/routes/vet/reference.js
+++ b/app/routes/vet/reference.js
@@ -2,13 +2,7 @@ const Joi = require('joi')
 const session = require('../../session')
 const { vetSignup: { reference: referenceKey } } = require('../../session/keys')
 const { reference: referenceErrorMessages } = require('../../../app/lib/error-messages')
-const { applicationRequestQueue, fetchApplicationRequestMsgType, applicationResponseQueue } = require('../../config')
-const { sendMessage, receiveMessage } = require('../../messaging')
-
-function getApplication (applicationReference, sessionId) {
-  sendMessage({ applicationReference, sessionId }, fetchApplicationRequestMsgType, applicationRequestQueue, { sessionId })
-  return receiveMessage(sessionId, applicationResponseQueue)
-}
+const { getApplication } = require('../../messaging/application')
 
 module.exports = [{
   method: 'GET',

--- a/app/routes/vet/visit-date.js
+++ b/app/routes/vet/visit-date.js
@@ -4,7 +4,7 @@ const getDateInputErrors = require('../../lib/visit-date/date-input-errors')
 const createItems = require('../../lib/visit-date/date-input-items')
 const { isDateInFutureOrBeforeFirstValidDate } = require('../../lib/visit-date/validation')
 const session = require('../../session')
-const { vetVisitData: { farmerApplication } } = require('../../session/keys')
+const { vetVisitData: { farmerApplication, visitDate } } = require('../../session/keys')
 
 const templatePath = 'vet/visit-date'
 const path = `/${templatePath}`
@@ -14,8 +14,8 @@ module.exports = [{
   path,
   options: {
     handler: async (request, h) => {
-      // TODO: pull the date from the session
-      return h.view(templatePath)
+      const items = session.getVetVisitData(request, visitDate)
+      return h.view(templatePath, { items })
     }
   }
 }, {
@@ -52,6 +52,8 @@ module.exports = [{
         }
         return h.view(templatePath, { ...request.payload, ...dateInputErrors }).code(400).takeover()
       }
+      const items = createItems(request.payload, false)
+      session.setVetVisitData(request, visitDate, items)
       return h.redirect('/vet/species')
     }
   }

--- a/app/session/index.js
+++ b/app/session/index.js
@@ -1,7 +1,8 @@
 const entries = {
   application: 'application',
   organisation: 'organisation',
-  vetSignup: 'vetSignup'
+  vetSignup: 'vetSignup',
+  vetVisitData: 'vetVisitData'
 }
 
 function set (request, entryKey, key, value) {
@@ -26,6 +27,10 @@ function setVetSignup (request, key, value) {
   set(request, entries.vetSignup, key, value)
 }
 
+function setVetVisitData (request, key, value) {
+  set(request, entries.vetVisitData, key, value)
+}
+
 function getApplication (request, key) {
   return get(request, entries.application, key)
 }
@@ -38,11 +43,17 @@ function getVetSignup (request, key) {
   return get(request, entries.vetSignup, key)
 }
 
+function getVetVisitData (request, key) {
+  return get(request, entries.vetVisitData, key)
+}
+
 module.exports = {
   getApplication,
   getOrganisation,
   getVetSignup,
+  getVetVisitData,
   setApplication,
   setOrganisation,
-  setVetSignup
+  setVetSignup,
+  setVetVisitData
 }

--- a/app/session/keys.js
+++ b/app/session/keys.js
@@ -11,5 +11,9 @@ module.exports = {
     practice: 'practice',
     rcvs: 'rcvs',
     reference: 'reference'
+  },
+  vetVisitData: {
+    farmerApplication: 'farmerApplication',
+    signup: 'signup'
   }
 }

--- a/app/session/keys.js
+++ b/app/session/keys.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   vetVisitData: {
     farmerApplication: 'farmerApplication',
-    signup: 'signup'
+    signup: 'signup',
+    visitDate: 'visitDate'
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/vet/email.test.js
+++ b/test/integration/narrow/routes/vet/email.test.js
@@ -4,8 +4,6 @@ const expectPhaseBanner = require('../../../../utils/phase-banner-expect')
 const pageExpects = require('../../../../utils/page-expects')
 const { email: emailErrorMessages } = require('../../../../../app/lib/error-messages')
 const { vetSignup: { email: emailKey } } = require('../../../../../app/session/keys')
-const { notify: { templateIdVetLogin } } = require('../../../../../app/config')
-const { vet } = require('../../../../../app/config/user-types')
 
 function expectPageContentOk ($) {
   expect($('h1').text()).toMatch('Enter your email address')

--- a/test/integration/narrow/routes/vet/email.test.js
+++ b/test/integration/narrow/routes/vet/email.test.js
@@ -91,6 +91,8 @@ describe('Vet, enter email name test', () => {
       { email: validEmail },
       { email: `  ${validEmail}  ` }
     ])('returns 302 when payload is valid, sends email and stores email in session (email = "$email")', async ({ email }) => {
+      const signupData = {}
+      session.getVetSignup.mockReturnValueOnce(signupData)
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         headers: { cookie: `crumb=${crumb}` },
@@ -107,10 +109,12 @@ describe('Vet, enter email name test', () => {
       expect(session.setVetSignup).toHaveBeenCalledTimes(1)
       expect(session.setVetSignup).toHaveBeenCalledWith(res.request, emailKey, email.trim())
       expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1)
-      expect(sendMagicLinkEmail).toHaveBeenCalledWith(res.request, email.trim(), templateIdVetLogin, 'vet/visit-date', vet)
+      expect(sendMagicLinkEmail).toHaveBeenCalledWith(res.request, email.trim(), templateIdVetLogin, 'vet/visit-date', vet, signupData)
     })
 
     test('returns 500 when problem sending email', async () => {
+      const signupData = {}
+      session.getVetSignup.mockReturnValueOnce(signupData)
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         headers: { cookie: `crumb=${crumb}` },
@@ -125,7 +129,7 @@ describe('Vet, enter email name test', () => {
       expect(session.setVetSignup).toHaveBeenCalledTimes(1)
       expect(session.setVetSignup).toHaveBeenCalledWith(res.request, emailKey, validEmail)
       expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1)
-      expect(sendMagicLinkEmail).toHaveBeenCalledWith(res.request, validEmail, templateIdVetLogin, 'vet/visit-date', vet)
+      expect(sendMagicLinkEmail).toHaveBeenCalledWith(res.request, validEmail, templateIdVetLogin, 'vet/visit-date', vet, signupData)
       expect(res.statusCode).toBe(500)
       const $ = cheerio.load(res.payload)
       expect($('h1').text()).toEqual('Sorry, there is a problem with the service')

--- a/test/integration/narrow/routes/vet/email.test.js
+++ b/test/integration/narrow/routes/vet/email.test.js
@@ -100,7 +100,7 @@ describe('Vet, enter email name test', () => {
         payload: { crumb, email },
         url
       }
-      sendMagicLinkEmail.mockResolvedValue(true)
+      sendMagicLinkEmail.sendVetMagicLinkEmail.mockResolvedValue(true)
 
       const res = await global.__SERVER__.inject(options)
 
@@ -108,8 +108,8 @@ describe('Vet, enter email name test', () => {
       expect(res.headers.location).toEqual('/vet/check-email')
       expect(session.setVetSignup).toHaveBeenCalledTimes(1)
       expect(session.setVetSignup).toHaveBeenCalledWith(res.request, emailKey, email.trim())
-      expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1)
-      expect(sendMagicLinkEmail).toHaveBeenCalledWith(res.request, email.trim(), templateIdVetLogin, 'vet/visit-date', vet, signupData)
+      expect(sendMagicLinkEmail.sendVetMagicLinkEmail).toHaveBeenCalledTimes(1)
+      expect(sendMagicLinkEmail.sendVetMagicLinkEmail).toHaveBeenCalledWith(res.request, email.trim(), signupData)
     })
 
     test('returns 500 when problem sending email', async () => {
@@ -122,14 +122,14 @@ describe('Vet, enter email name test', () => {
         payload: { crumb, email: validEmail },
         url
       }
-      sendMagicLinkEmail.mockResolvedValue(false)
+      sendMagicLinkEmail.sendVetMagicLinkEmail.mockResolvedValue(false)
 
       const res = await global.__SERVER__.inject(options)
 
       expect(session.setVetSignup).toHaveBeenCalledTimes(1)
       expect(session.setVetSignup).toHaveBeenCalledWith(res.request, emailKey, validEmail)
-      expect(sendMagicLinkEmail).toHaveBeenCalledTimes(1)
-      expect(sendMagicLinkEmail).toHaveBeenCalledWith(res.request, validEmail, templateIdVetLogin, 'vet/visit-date', vet, signupData)
+      expect(sendMagicLinkEmail.sendVetMagicLinkEmail).toHaveBeenCalledTimes(1)
+      expect(sendMagicLinkEmail.sendVetMagicLinkEmail).toHaveBeenCalledWith(res.request, validEmail, signupData)
       expect(res.statusCode).toBe(500)
       const $ = cheerio.load(res.payload)
       expect($('h1').text()).toEqual('Sorry, there is a problem with the service')

--- a/test/integration/narrow/routes/vet/visit-date.test.js
+++ b/test/integration/narrow/routes/vet/visit-date.test.js
@@ -1,7 +1,8 @@
 const cheerio = require('cheerio')
 const getCrumbs = require('../../../../utils/get-crumbs')
 const expectPhaseBanner = require('../../../../utils/phase-banner-expect')
-const { inputErrorClass, labels, startDateString } = require('../../../../../app/config/visit-date')
+const { inputErrorClass, labels } = require('../../../../../app/config/visit-date')
+const { vetVisitData: { farmerApplication } } = require('../../../../../app/session/keys')
 
 function expectPageContentOk ($) {
   expect($('h1').text()).toMatch('When did the review take place with the farmer?')
@@ -12,6 +13,9 @@ function expectPageContentOk ($) {
   expect($('title').text()).toEqual('Enter the date of the visit')
   expect($('.govuk-back-link').length).toEqual(0)
 }
+
+const session = require('../../../../../app/session')
+jest.mock('../../../../../app/session')
 
 describe('Vet, enter date of visit', () => {
   const auth = { credentials: {}, strategy: 'cookie' }
@@ -55,12 +59,15 @@ describe('Vet, enter date of visit', () => {
     const method = 'POST'
     const today = new Date()
     const yearFuture = new Date()
-    yearFuture.setFullYear(yearFuture.getFullYear() + 2)
+    yearFuture.setFullYear(yearFuture.getFullYear() + 1)
     const yearPast = new Date()
-    yearPast.setFullYear(yearPast.getFullYear() - 2)
+    yearPast.setFullYear(yearPast.getFullYear() - 1)
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
     const tomorrow = new Date()
     tomorrow.setDate(tomorrow.getDate() + 1)
-    const startDate = new Date(startDateString)
+    const createdAt = Date.now()
+    const startDate = new Date(createdAt)
     const dayBeforeStartDate = new Date(startDate)
     dayBeforeStartDate.setDate(dayBeforeStartDate.getDate() - 1)
 
@@ -83,31 +90,11 @@ describe('Vet, enter date of visit', () => {
     })
 
     test.each([
-      { day: '', month: '', year: '', date: '', errorMessage: 'Enter the date of the visit' },
-      { day: tomorrow.getDate(), month: tomorrow.getMonth() + 1, year: tomorrow.getFullYear(), date: tomorrow, errorMessage: 'Visit date must be today or in the past' },
-      { day: yearFuture.getDate(), month: yearFuture.getMonth() + 1, year: yearFuture.getFullYear(), date: yearFuture, errorMessage: 'Visit date must be today or in the past' },
-      { day: yearPast.getDate(), month: yearPast.getMonth() + 1, year: yearPast.getFullYear(), date: yearPast, errorMessage: `Visit date must be the same as or after ${startDate.toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}` },
-      { day: dayBeforeStartDate.getDate(), month: dayBeforeStartDate.getMonth() + 1, year: dayBeforeStartDate.getFullYear(), date: tomorrow, errorMessage: `Visit date must be the same as or after ${startDate.toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}` }
-    ])('returns error ($errorMessage) when unacceptable answer is given - $date', async ({ day, month, year, errorMessage }) => {
-      const options = {
-        method,
-        url,
-        payload: { crumb, [labels.day]: day, [labels.month]: month, [labels.year]: year },
-        auth,
-        headers: { cookie: `crumb=${crumb}` }
-      }
-
-      const res = await global.__SERVER__.inject(options)
-
-      const $ = cheerio.load(res.payload)
-      expect(res.statusCode).toBe(400)
-      expect($('p.govuk-error-message').text()).toMatch(errorMessage)
-      expect($(`#${labels.day}`).hasClass(inputErrorClass)).toEqual(true)
-      expect($(`#${labels.month}`).hasClass(inputErrorClass)).toEqual(true)
-      expect($(`#${labels.year}`).hasClass(inputErrorClass)).toEqual(true)
-    })
-
-    test.each([
+      { day: '', month: '', year: '', date: '', errorMessage: 'Enter the date of the visit', errorHighlights: [labels.day, labels.month, labels.year] },
+      { day: tomorrow.getDate(), month: tomorrow.getMonth() + 1, year: tomorrow.getFullYear(), date: tomorrow, errorMessage: 'Visit date must be today or in the past', errorHighlights: [labels.day, labels.month, labels.year] },
+      { day: yearFuture.getDate(), month: yearFuture.getMonth() + 1, year: yearFuture.getFullYear(), date: yearFuture, errorMessage: 'Visit date must be today or in the past', errorHighlights: [labels.day, labels.month, labels.year] },
+      { day: yearPast.getDate(), month: yearPast.getMonth() + 1, year: yearPast.getFullYear(), date: yearPast, errorMessage: `Visit date must be the same as or after ${startDate.toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}`, errorHighlights: [labels.day, labels.month, labels.year] },
+      { day: dayBeforeStartDate.getDate(), month: dayBeforeStartDate.getMonth() + 1, year: dayBeforeStartDate.getFullYear(), date: tomorrow, errorMessage: `Visit date must be the same as or after ${startDate.toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}`, errorHighlights: [labels.day, labels.month, labels.year] },
       { day: '', month: startDate.getMonth(), year: startDate.getFullYear(), errorMessage: 'Visit date must include a day', errorHighlights: [labels.day] },
       { day: startDate.getDate(), month: '', year: startDate.getFullYear(), errorMessage: 'Visit date must include a month', errorHighlights: [labels.month] },
       { day: startDate.getDate(), month: startDate.getMonth(), year: '', errorMessage: 'Visit date must include a year', errorHighlights: [labels.year] },
@@ -115,6 +102,7 @@ describe('Vet, enter date of visit', () => {
       { day: '', month: startDate.getMonth(), year: '', errorMessage: 'Visit date must include a day and a year', errorHighlights: [labels.day, labels.year] },
       { day: startDate.getDate(), month: '', year: '', errorMessage: 'Visit date must include a month and a year', errorHighlights: [labels.month, labels.year] }
     ])('returns error ($errorMessage) when partial input is given - $description', async ({ day, month, year, errorMessage, errorHighlights }) => {
+      session.getVetVisitData.mockReturnValueOnce({ createdAt: startDate })
       const options = {
         method,
         url,
@@ -131,12 +119,15 @@ describe('Vet, enter date of visit', () => {
       errorHighlights.forEach(label => {
         expect($(`#${label}`).hasClass(inputErrorClass)).toEqual(true)
       })
+      expect(session.getVetVisitData).toHaveBeenCalledTimes(1)
+      expect(session.getVetVisitData).toHaveBeenCalledWith(res.request, farmerApplication)
     })
 
     test.each([
       { day: today.getDate(), month: today.getMonth() + 1, year: today.getFullYear(), description: 'today', date: today },
       { day: startDate.getDate(), month: startDate.getMonth() + 1, year: startDate.getFullYear(), description: 'first possible date', date: startDate }
     ])('returns 302 to next page when acceptable answer given - $description ($date)', async ({ day, month, year }) => {
+      session.getVetVisitData.mockReturnValueOnce({ createdAt: yesterday })
       const options = {
         method,
         url,
@@ -149,6 +140,8 @@ describe('Vet, enter date of visit', () => {
 
       expect(res.statusCode).toBe(302)
       expect(res.headers.location).toEqual('/vet/species')
+      expect(session.getVetVisitData).toHaveBeenCalledTimes(1)
+      expect(session.getVetVisitData).toHaveBeenCalledWith(res.request, farmerApplication)
     })
   })
 })

--- a/test/integration/narrow/routes/vet/visit-date.test.js
+++ b/test/integration/narrow/routes/vet/visit-date.test.js
@@ -52,6 +52,26 @@ describe('Vet, enter date of visit', () => {
       expectPageContentOk($)
       expectPhaseBanner.ok($)
     })
+
+    test('loads input dates, if in session', async () => {
+      const items = [{ name: 'day', value: 31 }, { name: 'month', value: 12 }, { name: 'year', value: 2022 }]
+      const options = {
+        method: 'GET',
+        url,
+        auth
+      }
+      session.getVetVisitData.mockReturnValue(items)
+
+      const res = await global.__SERVER__.inject(options)
+
+      expect(res.statusCode).toBe(200)
+      const $ = cheerio.load(res.payload)
+      expectPageContentOk($)
+      expectPhaseBanner.ok($)
+      expect($(`#${labels.day}`).val()).toEqual(items[0].value.toString())
+      expect($(`#${labels.month}`).val()).toEqual(items[1].value.toString())
+      expect($(`#${labels.year}`).val()).toEqual(items[2].value.toString())
+    })
   })
 
   describe(`POST to ${url} route`, () => {

--- a/test/unit/app/lib/error-messages/date-input-errors.test.js
+++ b/test/unit/app/lib/error-messages/date-input-errors.test.js
@@ -98,10 +98,11 @@ describe('date input error message', () => {
     expect(errorItems).toHaveLength(3)
   })
 
+  const firstValidDate = new Date(2022, 6, 13)
   test.each([
     { label: `${labelPrefix}day`, value: 999, expectedErrorMessage: 'Visit date must be today or in the past' },
     { label: `${labelPrefix}month`, value: 999, expectedErrorMessage: 'Visit date must be today or in the past' },
-    { label: `${labelPrefix}year`, value: 999, expectedErrorMessage: 'Visit date must be the same as or after 1 April 2022' }
+    { label: `${labelPrefix}year`, value: 999, expectedErrorMessage: `Visit date must be the same as or after ${firstValidDate.toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })} when the application was created` }
   ])('returns all items highlighted with values set - %p', ({ label, value, expectedErrorMessage }) => {
     const errorDetails = [{
       context: { label, value, key: label }
@@ -109,7 +110,7 @@ describe('date input error message', () => {
     const payload = { ...fullPayload }
     payload[label] = value
 
-    const { errorMessage, items } = getDateInputErrors(errorDetails, payload)
+    const { errorMessage, items } = getDateInputErrors(errorDetails, payload, firstValidDate)
 
     expect(errorMessage.text).toEqual(expectedErrorMessage)
     expect(items).toHaveLength(3)

--- a/test/unit/app/session/index.test.js
+++ b/test/unit/app/session/index.test.js
@@ -1,113 +1,85 @@
 const session = require('../../../../app/session')
 
 describe('session', () => {
-  const getApplication = 'getApplication'
-  const getOrganisation = 'getOrganisation'
-  const getVetSignup = 'getVetSignup'
-  const setApplication = 'setApplication'
-  const setOrganisation = 'setOrganisation'
-  const setVetSignup = 'setVetSignup'
   const applicationSectionKey = 'application'
   const organisationSectionKey = 'organisation'
   const vetSignupSectionKey = 'vetSignup'
+  const vetVisitSectionKey = 'vetVisitData'
 
   const value = 'value'
   const objectValue = { key: value }
 
-  test.each([
-    { func: getApplication, expectedSectionKey: applicationSectionKey, key: 'key', value },
-    { func: getApplication, expectedSectionKey: applicationSectionKey, key: 'unknown', value: undefined },
-    { func: getApplication, expectedSectionKey: applicationSectionKey, key: false, value: objectValue },
-    { func: getApplication, expectedSectionKey: applicationSectionKey, key: null, value: objectValue },
-    { func: getApplication, expectedSectionKey: applicationSectionKey, key: undefined, value: objectValue },
-    { func: getOrganisation, expectedSectionKey: organisationSectionKey, key: 'key', value },
-    { func: getOrganisation, expectedSectionKey: organisationSectionKey, key: 'unknown', value: undefined },
-    { func: getOrganisation, expectedSectionKey: organisationSectionKey, key: false, value: objectValue },
-    { func: getOrganisation, expectedSectionKey: organisationSectionKey, key: null, value: objectValue },
-    { func: getOrganisation, expectedSectionKey: organisationSectionKey, key: undefined, value: objectValue },
-    { func: getVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'key', value },
-    { func: getVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'unknown', value: undefined },
-    { func: getVetSignup, expectedSectionKey: vetSignupSectionKey, key: false, value: objectValue },
-    { func: getVetSignup, expectedSectionKey: vetSignupSectionKey, key: null, value: objectValue },
-    { func: getVetSignup, expectedSectionKey: vetSignupSectionKey, key: undefined, value: objectValue }
-  ])('$func retrieves value from $expectedSectionKey based on key (key value - $key)', async ({ func, expectedSectionKey, key, value }) => {
-    let sectionKey
-    const requestGetMock = { yar: { get: (entryKey) => { sectionKey = entryKey; return objectValue } } }
+  const getFunctionsToTest = [
+    { func: 'getApplication', expectedSectionKey: applicationSectionKey },
+    { func: 'getOrganisation', expectedSectionKey: organisationSectionKey },
+    { func: 'getVetSignup', expectedSectionKey: vetSignupSectionKey },
+    { func: 'getVetVisitData', expectedSectionKey: vetVisitSectionKey }
+  ]
 
-    const application = session[func](requestGetMock, key)
+  const setFunctionsToTest = [
+    { func: 'setApplication', expectedSectionKey: applicationSectionKey },
+    { func: 'setOrganisation', expectedSectionKey: organisationSectionKey },
+    { func: 'setVetSignup', expectedSectionKey: vetSignupSectionKey },
+    { func: 'setVetVisitData', expectedSectionKey: vetVisitSectionKey }
+  ]
 
-    expect(application).toEqual(value)
-    expect(sectionKey).toEqual(expectedSectionKey)
+  const keysAndValuesToTest = [
+    { key: 'key', value },
+    { key: 'unknown', value: undefined },
+    { key: false, value: objectValue },
+    { key: null, value: objectValue },
+    { key: undefined, value: objectValue }
+  ]
+
+  describe.each(getFunctionsToTest)('"$func" retrieves value from "$expectedSectionKey" based on key value', ({ func, expectedSectionKey }) => {
+    test.each(keysAndValuesToTest)('key value - $key', async ({ key, value }) => {
+      let sectionKey
+      const requestGetMock = { yar: { get: (entryKey) => { sectionKey = entryKey; return objectValue } } }
+
+      const application = session[func](requestGetMock, key)
+
+      expect(application).toEqual(value)
+      expect(sectionKey).toEqual(expectedSectionKey)
+    })
   })
 
-  test.each([
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: 'key', value },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: 'unknown', value: undefined },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: false, value: objectValue },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: null, value: objectValue },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: undefined, value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: 'key', value },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: 'unknown', value: undefined },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: false, value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: null, value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: undefined, value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'key', value },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'unknown', value: undefined },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: false, value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: null, value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: undefined, value: objectValue }
-  ])('$func sets value in $expectedSectionKey based on the key (key value - $key) when no value exists in $expectedSectionKey', async ({ func, expectedSectionKey, key, value }) => {
-    const yarMock = {
-      get: jest.fn(),
-      set: jest.fn()
-    }
-    const requestSetMock = { yar: yarMock }
+  describe.each(setFunctionsToTest)('"$func" sets value in "$expectedSectionKey" based on key value when no value exists in "$expectedSectionKey"', ({ func, expectedSectionKey }) => {
+    test.each(keysAndValuesToTest)('key value - $key', async ({ key, value }) => {
+      const yarMock = {
+        get: jest.fn(),
+        set: jest.fn()
+      }
+      const requestSetMock = { yar: yarMock }
 
-    session[func](requestSetMock, key, value)
+      session[func](requestSetMock, key, value)
 
-    expect(requestSetMock.yar.get).toHaveBeenCalledTimes(1)
-    expect(requestSetMock.yar.get).toHaveBeenCalledWith(expectedSectionKey)
-    expect(requestSetMock.yar.set).toHaveBeenCalledTimes(1)
-    expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { [key]: value })
+      expect(requestSetMock.yar.get).toHaveBeenCalledTimes(1)
+      expect(requestSetMock.yar.get).toHaveBeenCalledWith(expectedSectionKey)
+      expect(requestSetMock.yar.set).toHaveBeenCalledTimes(1)
+      expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { [key]: value })
+    })
   })
 
-  test.each([
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: 'key', value },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: 'unknown', value: undefined },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: false, value: objectValue },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: null, value: objectValue },
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: undefined, value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: 'key', value },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: 'unknown', value: undefined },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: false, value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: null, value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: undefined, value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'key', value },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'unknown', value: undefined },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: false, value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: null, value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: undefined, value: objectValue }
-  ])('$func sets value in $expectedSectionKey based on the key (key value - $key) when a value already exists in $expectedSectionKey', async ({ func, expectedSectionKey, key, value }) => {
-    const existingValue = { existingKey: 'existing-value' }
-    const yarMock = {
-      get: jest.fn(() => existingValue),
-      set: jest.fn()
-    }
-    const requestSetMock = { yar: yarMock }
+  describe.each(setFunctionsToTest)('"$func" sets value in "$expectedSectionKey" based on key when a value already exists in "$expectedSectionKey"', ({ func, expectedSectionKey }) => {
+    test.each(keysAndValuesToTest)('key value - $key', async ({ key, value }) => {
+      const existingValue = { existingKey: 'existing-value' }
+      const yarMock = {
+        get: jest.fn(() => existingValue),
+        set: jest.fn()
+      }
+      const requestSetMock = { yar: yarMock }
 
-    session[func](requestSetMock, key, value)
+      session[func](requestSetMock, key, value)
 
-    expect(requestSetMock.yar.get).toHaveBeenCalledTimes(1)
-    expect(requestSetMock.yar.get).toHaveBeenCalledWith(expectedSectionKey)
-    expect(requestSetMock.yar.set).toHaveBeenCalledTimes(1)
-    expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { ...{ [key]: value }, ...existingValue })
+      expect(requestSetMock.yar.get).toHaveBeenCalledTimes(1)
+      expect(requestSetMock.yar.get).toHaveBeenCalledWith(expectedSectionKey)
+      expect(requestSetMock.yar.set).toHaveBeenCalledTimes(1)
+      expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { ...{ [key]: value }, ...existingValue })
+    })
   })
 
-  test.each([
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: 'key', value: '    to be trimmed   ' },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: 'key', value: '    to be trimmed   ' },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'key', value: '    to be trimmed   ' }
-  ])('$func sets value once trimmed when the value is a string (value = "$value")', async ({ func, expectedSectionKey, value }) => {
+  const valueToBeTrimmed = '    to be trimmed   '
+  test.each(setFunctionsToTest)(`"$func" sets value once trimmed, when the value is a string (value = "${valueToBeTrimmed}")`, async ({ func, expectedSectionKey }) => {
     const key = 'key'
     const yarMock = {
       get: jest.fn(),
@@ -115,19 +87,15 @@ describe('session', () => {
     }
     const requestSetMock = { yar: yarMock }
 
-    session[func](requestSetMock, key, value)
+    session[func](requestSetMock, key, valueToBeTrimmed)
 
     expect(requestSetMock.yar.get).toHaveBeenCalledTimes(1)
     expect(requestSetMock.yar.get).toHaveBeenCalledWith(expectedSectionKey)
     expect(requestSetMock.yar.set).toHaveBeenCalledTimes(1)
-    expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { [key]: value.trim() })
+    expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { [key]: valueToBeTrimmed.trim() })
   })
 
-  test.each([
-    { func: setApplication, expectedSectionKey: applicationSectionKey, key: 'key', value: objectValue },
-    { func: setOrganisation, expectedSectionKey: organisationSectionKey, key: 'key', value: objectValue },
-    { func: setVetSignup, expectedSectionKey: vetSignupSectionKey, key: 'key', value: objectValue }
-  ])('$func does not trim value when the value is not a string (value = "$value")', async ({ func, expectedSectionKey, value }) => {
+  test.each(setFunctionsToTest)(`"$func" does not trim value when the value is not a string (value = "${objectValue}")`, async ({ func, expectedSectionKey }) => {
     const key = 'key'
     const yarMock = {
       get: jest.fn(),
@@ -135,11 +103,11 @@ describe('session', () => {
     }
     const requestSetMock = { yar: yarMock }
 
-    session[func](requestSetMock, key, value)
+    session[func](requestSetMock, key, objectValue)
 
     expect(requestSetMock.yar.get).toHaveBeenCalledTimes(1)
     expect(requestSetMock.yar.get).toHaveBeenCalledWith(expectedSectionKey)
     expect(requestSetMock.yar.set).toHaveBeenCalledTimes(1)
-    expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { [key]: value })
+    expect(requestSetMock.yar.set).toHaveBeenCalledWith(expectedSectionKey, { [key]: objectValue })
   })
 })


### PR DESCRIPTION
Changes are mostly for the ability to validate the visit date against the application created date, however, there is a bit of refactoring thrown in too.
In order for the visit date to be validated, the reference to the application is required which allows for retrieval of the application and then the date it was created is knowable.
The data from the vet signup stage is cached when the magic link email is sent to the vet. When the login is verified the reference from the cache is used to retrieve the application which is then cached.