### PR TITLE
refactor: fix cookie setting update, misc tweaks

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -22,6 +22,7 @@ const schema = Joi.object({
     }
   },
   cookie: {
+    cookieNameCookiePolicy: Joi.string().default('ffc_ahwr_cookie_policy'),
     cookieNameAuth: Joi.string().default('ffc_ahwr_auth'),
     cookieNameSession: Joi.string().default('ffc_ahwr_session'),
     isSameSite: Joi.string().default('Lax'),
@@ -88,6 +89,7 @@ const config = {
     }
   },
   cookie: {
+    cookieNameCookiePolicy: 'ffc_ahwr_cookie_policy',
     cookieNameAuth: 'ffc_ahwr_auth',
     cookieNameSession: 'ffc_ahwr_session',
     isSameSite: 'Lax',

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -30,14 +30,12 @@ const schema = Joi.object({
     password: Joi.string().min(32).required()
   },
   cookiePolicy: {
-    password: Joi.string().min(32).required(),
-    ttl: Joi.number().default(1000 * 60 * 60 * 24 * 365), // 1 year
-    isSameSite: Joi.string().valid('Lax').default('Lax'),
-    encoding: Joi.string().valid('base64json').default('base64json'),
-    isSecure: Joi.bool().default(true),
-    isHttpOnly: Joi.bool().default(true),
     clearInvalid: Joi.bool().default(false),
-    strictHeader: Joi.bool().default(true)
+    encoding: Joi.string().valid('base64json').default('base64json'),
+    isSameSite: Joi.string().default('Lax'),
+    isSecure: Joi.bool().default(true),
+    password: Joi.string().min(32).required(),
+    ttl: Joi.number().default(1000 * 60 * 60 * 24 * 365) // 1 year
   },
   env: Joi.string().valid('development', 'test', 'production').default('development'),
   isDev: Joi.boolean().default(false),
@@ -97,12 +95,9 @@ const config = {
     password: process.env.COOKIE_PASSWORD
   },
   cookiePolicy: {
-    encoding: 'base64json',
-    ttl: process.env.COOKIE_TTL_IN_MILLIS,
-    isSameSite: 'Lax',
     clearInvalid: false,
-    strictHeader: true,
-    isHttpOnly: true,
+    encoding: 'base64json',
+    isSameSite: 'Lax',
     isSecure: process.env.NODE_ENV === 'production',
     password: process.env.COOKIE_PASSWORD
   },

--- a/app/cookies.js
+++ b/app/cookies.js
@@ -1,7 +1,7 @@
-const config = require('./config').cookiePolicy
+const { cookie: { cookieNameCookiePolicy }, cookiePolicy } = require('./config')
 
 function getCurrentPolicy (request, h) {
-  let cookiesPolicy = request.state.cookies_policy
+  let cookiesPolicy = request.state[cookieNameCookiePolicy]
   if (!cookiesPolicy) {
     cookiesPolicy = createDefaultPolicy(h)
   }
@@ -10,12 +10,12 @@ function getCurrentPolicy (request, h) {
 
 function createDefaultPolicy (h) {
   const cookiesPolicy = { confirmed: false, essential: true, analytics: false }
-  h.state('cookies_policy', cookiesPolicy, config)
+  h.state(cookieNameCookiePolicy, cookiesPolicy, cookiePolicy)
   return cookiesPolicy
 }
 
 function updatePolicy (request, h, analytics) {
-  let cookiesPolicy = request.state.cookies_policy
+  let cookiesPolicy = request.state[cookieNameCookiePolicy]
   if (!cookiesPolicy) {
     cookiesPolicy = createDefaultPolicy(h)
   }
@@ -23,7 +23,7 @@ function updatePolicy (request, h, analytics) {
   cookiesPolicy.analytics = analytics
   cookiesPolicy.confirmed = true
 
-  h.state('cookies_policy', cookiesPolicy, config)
+  h.state(cookieNameCookiePolicy, cookiesPolicy, cookiePolicy)
 }
 
 module.exports = {

--- a/app/plugins/cookies.js
+++ b/app/plugins/cookies.js
@@ -1,11 +1,11 @@
-const config = require('../config').cookiePolicy
+const { cookie: { cookieNameCookiePolicy }, cookiePolicy } = require('../config')
 const { getCurrentPolicy } = require('../cookies')
 
 module.exports = {
   plugin: {
     name: 'cookies',
     register: (server, _) => {
-      server.state('cookies_policy', config)
+      server.state(cookieNameCookiePolicy, cookiePolicy)
 
       server.ext('onPreResponse', (request, h) => {
         const statusCode = request.response.statusCode

--- a/app/routes/cookies.js
+++ b/app/routes/cookies.js
@@ -1,6 +1,7 @@
 const Joi = require('joi')
 const ViewModel = require('./models/cookies-policy')
 const { updatePolicy } = require('../cookies')
+const { cookie: { cookieNameCookiePolicy } } = require('../config')
 
 module.exports = [{
   method: 'GET',
@@ -8,7 +9,7 @@ module.exports = [{
   options: {
     auth: false,
     handler: async (request, h) => {
-      return h.view('cookies/cookie-policy', new ViewModel(request.state.cookies_policy, request.query.updated))
+      return h.view('cookies/cookie-policy', new ViewModel(request.state[cookieNameCookiePolicy], request.query.updated))
     }
   }
 }, {

--- a/app/server.js
+++ b/app/server.js
@@ -32,12 +32,12 @@ async function createServer () {
   await server.register(require('@hapi/crumb'))
   await server.register(require('@hapi/inert'))
   await server.register(require('./plugins/auth'))
+  await server.register(require('./plugins/cookies'))
   await server.register(require('./plugins/error-pages'))
   await server.register(require('./plugins/logging'))
   await server.register(require('./plugins/router'))
   await server.register(require('./plugins/session'))
   await server.register(require('./plugins/views'))
-  await server.register(require('./plugins/cookies'))
 
   if (config.isDev) {
     await server.register(require('blipp'))

--- a/app/views/cookies/cookie-policy.njk
+++ b/app/views/cookies/cookie-policy.njk
@@ -1,11 +1,5 @@
 {% extends './layouts/layout.njk' %}
 
-{% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",

--- a/app/views/cookies/cookie-policy.njk
+++ b/app/views/cookies/cookie-policy.njk
@@ -117,7 +117,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l">Change your cookie settings</h2>
       <form action="/cookies" method="post" novalidate>
-        <input type="hidden" name="crumb" value="{{crumb}}"/>
+        <input type="hidden" name="async" value="false"/>
         {{ govukRadios(analytics) }}
         {{ govukButton({
           text: "Save cookie settings",

--- a/app/views/cookies/cookie-policy.njk
+++ b/app/views/cookies/cookie-policy.njk
@@ -11,9 +11,7 @@
 
   {% if updated %}
     {% set html %}
-      <p class="govuk-notification-banner__heading">
-        You’ve set your cookie preferences. <a class="govuk-notification-banner__link" href="/">Go back to the page you were looking at</a>.
-      </p>
+      <p class="govuk-notification-banner__heading">You’ve set your cookie preferences.</p>
     {% endset %}
 
     {{ govukNotificationBanner({

--- a/app/views/layouts/_layout.njk
+++ b/app/views/layouts/_layout.njk
@@ -60,12 +60,12 @@
     meta: {
       items: [
         {
-          href: "/cookies",
-          text: "Cookies"
-        },
-        {
           href: "/accessibility",
           text: "Accessibility"
+        },
+        {
+          href: "/cookies",
+          text: "Cookies"
         }
       ]
     }

--- a/app/views/layouts/_layout.njk
+++ b/app/views/layouts/_layout.njk
@@ -1,20 +1,21 @@
 {% extends "govuk/template.njk" %}
 
-{% from "govuk/components/back-link/macro.njk"    import govukBackLink %}
-{% from "govuk/components/breadcrumbs/macro.njk"  import govukBreadcrumbs %}
-{% from "govuk/components/button/macro.njk"       import govukButton %}
-{% from "govuk/components/date-input/macro.njk"   import govukDateInput %}
-{% from "govuk/components/details/macro.njk"      import govukDetails %}
-{% from "govuk/components/footer/macro.njk"       import govukFooter %}
-{% from "govuk/components/input/macro.njk"        import govukInput %}
-{% from "govuk/components/panel/macro.njk"        import govukPanel %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "govuk/components/radios/macro.njk"       import govukRadios %}
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/table/macro.njk"        import govukTable %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/back-link/macro.njk"           import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"         import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"              import govukButton %}
+{% from "govuk/components/date-input/macro.njk"          import govukDateInput %}
+{% from "govuk/components/details/macro.njk"             import govukDetails %}
+{% from "govuk/components/footer/macro.njk"              import govukFooter %}
+{% from "govuk/components/input/macro.njk"               import govukInput %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/panel/macro.njk"               import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"        import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"              import govukRadios %}
+{% from "govuk/components/summary-list/macro.njk"        import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"               import govukTable %}
+{% from "govuk/components/warning-text/macro.njk"        import govukWarningText %}
 
-{% from "../macros/search-box.njk"                import searchBox %}
+{% from "../macros/search-box.njk"                       import searchBox %}
 
 {% block pageTitle %}GOV.UK - Defra AHWR{% endblock %}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",

--- a/test/unit/app/cookies.test.js
+++ b/test/unit/app/cookies.test.js
@@ -1,3 +1,4 @@
+const { cookie: { cookieNameCookiePolicy } } = require('../../../app/config')
 const cookies = require('../../../app/cookies')
 let request
 let h
@@ -7,7 +8,7 @@ describe('cookies', () => {
   beforeEach(() => {
     request = {
       state: {
-        cookies_policy: undefined
+        [cookieNameCookiePolicy]: undefined
       }
     }
     h = {
@@ -26,17 +27,17 @@ describe('cookies', () => {
 
   test('getCurrentPolicy sets default cookie if does not exist', () => {
     cookies.getCurrentPolicy(request, h)
-    expect(h.state).toHaveBeenCalledWith('cookies_policy', defaultCookie, expect.anything())
+    expect(h.state).toHaveBeenCalledWith(cookieNameCookiePolicy, defaultCookie, expect.anything())
   })
 
   test('getCurrentPolicy returns cookie if exists', () => {
-    request.state.cookies_policy = { confirmed: true, essential: false, analytics: true }
+    request.state[cookieNameCookiePolicy] = { confirmed: true, essential: false, analytics: true }
     const result = cookies.getCurrentPolicy(request, h)
     expect(result).toStrictEqual({ confirmed: true, essential: false, analytics: true })
   })
 
   test('getCurrentPolicy does not set default cookie if exists', () => {
-    request.state.cookies_policy = { confirmed: true, essential: false, analytics: true }
+    request.state[cookieNameCookiePolicy] = { confirmed: true, essential: false, analytics: true }
     cookies.getCurrentPolicy(request, h)
     expect(h.state).not.toHaveBeenCalled()
   })
@@ -48,18 +49,18 @@ describe('cookies', () => {
 
   test('updatePolicy sets confirmed cookie second if does not exist', () => {
     cookies.updatePolicy(request, h, true)
-    expect(h.state).toHaveBeenNthCalledWith(2, 'cookies_policy', { confirmed: true, essential: true, analytics: true }, expect.anything())
+    expect(h.state).toHaveBeenNthCalledWith(2, cookieNameCookiePolicy, { confirmed: true, essential: true, analytics: true }, expect.anything())
   })
 
   test('updatePolicy sets cookie to accepted', () => {
-    request.state.cookies_policy = { confirmed: false, essential: true, analytics: false }
+    request.state[cookieNameCookiePolicy] = { confirmed: false, essential: true, analytics: false }
     cookies.updatePolicy(request, h, true)
-    expect(h.state).toHaveBeenCalledWith('cookies_policy', { confirmed: true, essential: true, analytics: true }, expect.anything())
+    expect(h.state).toHaveBeenCalledWith(cookieNameCookiePolicy, { confirmed: true, essential: true, analytics: true }, expect.anything())
   })
 
   test('updatePolicy sets cookie to rejected', () => {
-    request.state.cookies_policy = { confirmed: false, essential: true, analytics: false }
+    request.state[cookieNameCookiePolicy] = { confirmed: false, essential: true, analytics: false }
     cookies.updatePolicy(request, h, false)
-    expect(h.state).toHaveBeenCalledWith('cookies_policy', { confirmed: true, essential: true, analytics: false }, expect.anything())
+    expect(h.state).toHaveBeenCalledWith(cookieNameCookiePolicy, { confirmed: true, essential: true, analytics: false }, expect.anything())
   })
 })


### PR DESCRIPTION
I was reviewing #30 and figured it would be easier to make the changes rather than just comment on them - so I did!

Changes include:
* Alphabetising stuff
* Fixing the cookie update on the cookie page - it was erroring with a bad request
* Moving the component imports into `_layout` so they are all in one place and available to all views
* Updated the cookie name as this helps to avoid clashes locally and used a config variable for the name
