### PR TITLE
feat: better failed response handling for farmer apply

### DIFF
--- a/app/routes/vet/confirmation.js
+++ b/app/routes/vet/confirmation.js
@@ -21,7 +21,7 @@ module.exports = [{
   options: {
     handler: async (request, h) => {
       const vetVisitData = session.getVetVisitData(request)
-      sendMessage(vetVisitData, vetVisitRequestMsgType, applicationRequestQueue, { sessionId: request.yar.id })
+      await sendMessage(vetVisitData, vetVisitRequestMsgType, applicationRequestQueue, { sessionId: request.yar.id })
       const response = await receiveMessage(request.yar.id, applicationResponseQueue)
       console.info('Response received:', util.inspect(response, false, null, true))
       session.setVetSignup(request, applicationStateKey, response?.applicationState)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.51.0",
+  "version": "0.55.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/farmer-apply/declaration.test.js
+++ b/test/integration/narrow/routes/farmer-apply/declaration.test.js
@@ -4,6 +4,7 @@ const expectPhaseBanner = require('../../../../utils/phase-banner-expect')
 const { applicationRequestMsgType, applicationRequestQueue } = require('../../../../../app/config')
 const { farmerApplyData: { declaration } } = require('../../../../../app/session/keys')
 const species = require('../../../../../app/constants/species')
+const states = require('../../../../../app/constants/states')
 
 const sessionMock = require('../../../../../app/session')
 jest.mock('../../../../../app/session')
@@ -140,8 +141,8 @@ describe('Declaration test', () => {
       expect(sessionMock.getFarmerApplyData).toHaveBeenCalledWith(res.request)
     })
 
-    test('returns 500 when request is not valid and there is no message response', async () => {
-      messagingMock.receiveMessage.mockResolvedValueOnce(null)
+    test('returns 500 when request failed', async () => {
+      messagingMock.receiveMessage.mockResolvedValueOnce({ applicationState: states.failed })
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         method: 'POST',


### PR DESCRIPTION
Use the `applicationState` property on the response to determine when to show the exception page.