### PR TITLE
Declaration page generates multiple reference numbers.

### DIFF
--- a/app/routes/farmer-apply/declaration.js
+++ b/app/routes/farmer-apply/declaration.js
@@ -88,12 +88,10 @@ module.exports = [{
       }
     },
     handler: async (request, h) => {
-      let applicationReference = session.getFarmerApplyData(request, reference)
-
+      const application = session.getFarmerApplyData(request)
+      let applicationReference = application?.reference
       if (!applicationReference) {
         session.setFarmerApplyData(request, declaration, true)
-
-        const application = session.getFarmerApplyData(request)
         await sendMessage(application, applicationRequestMsgType, applicationRequestQueue, { sessionId: request.yar.id })
         const response = await receiveMessage(request.yar.id, applicationResponseQueue)
         applicationReference = response?.applicationReference

--- a/app/routes/farmer-apply/declaration.js
+++ b/app/routes/farmer-apply/declaration.js
@@ -89,7 +89,7 @@ module.exports = [{
     },
     handler: async (request, h) => {
       const application = session.getFarmerApplyData(request)
-      let applicationReference = application?.reference
+      let applicationReference = application[reference]
       if (!applicationReference) {
         session.setFarmerApplyData(request, declaration, true)
         await sendMessage(application, applicationRequestMsgType, applicationRequestQueue, { sessionId: request.yar.id })

--- a/app/session/keys.js
+++ b/app/session/keys.js
@@ -10,7 +10,8 @@ module.exports = {
     declaration: 'declaration',
     organisation: 'organisation',
     whichReview: 'whichReview',
-    confirmCheckDetails: 'confirmCheckDetails'
+    confirmCheckDetails: 'confirmCheckDetails',
+    reference: 'reference'
   },
   claim: {
     detailsCorrect: 'detailsCorrect'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.56.0",
+  "version": "0.58.0",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",


### PR DESCRIPTION
Refreshing the confirmation page currently generates a new reference number. This should not happen, only when an application is submitted should a reference number be generated.

https://eaflood.atlassian.net/browse/VVAHWR-359