### PR TITLE
fix: display correct message to vet for resubmissions

### DIFF
--- a/app/routes/vet/confirmation.js
+++ b/app/routes/vet/confirmation.js
@@ -1,8 +1,14 @@
 const util = require('util')
-const { applicationRequestQueue, vetVisitRequestMsgType, applicationResponseQueue } = require('../../config')
+const {
+  applicationRequestQueue,
+  vetVisitRequestMsgType,
+  applicationResponseQueue
+} = require('../../config')
 const { sendMessage, receiveMessage } = require('../../messaging')
 const session = require('../../session')
-const { vetSignup: { applicationState: applicationStateKey } } = require('../../session/keys')
+const { vetSignup: { applicationState: applicationStateKey } } = require(
+  '../../session/keys'
+)
 
 const path = 'vet/confirmation'
 module.exports = [{
@@ -21,11 +27,29 @@ module.exports = [{
   options: {
     handler: async (request, h) => {
       const vetVisitData = session.getVetVisitData(request)
-      await sendMessage(vetVisitData, vetVisitRequestMsgType, applicationRequestQueue, { sessionId: request.yar.id })
-      const response = await receiveMessage(request.yar.id, applicationResponseQueue)
-      console.info('Response received:', util.inspect(response, false, null, true))
-      session.setVetSignup(request, applicationStateKey, response?.applicationState)
-      return h.view(path, { applicationState: response?.applicationState, reference: vetVisitData?.signup?.reference })
+      await sendMessage(
+        vetVisitData,
+        vetVisitRequestMsgType,
+        applicationRequestQueue,
+        { sessionId: request.yar.id }
+      )
+      const response = await receiveMessage(
+        request.yar.id,
+        applicationResponseQueue
+      )
+      console.info(
+        'Response received:',
+        util.inspect(response, false, null, true)
+      )
+      session.setVetSignup(
+        request,
+        applicationStateKey,
+        response?.applicationState
+      )
+      return h.view(path, {
+        applicationState: response?.applicationState,
+        reference: vetVisitData?.signup?.reference
+      })
     }
   }
 }]

--- a/app/views/vet/confirmation.njk
+++ b/app/views/vet/confirmation.njk
@@ -5,7 +5,9 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    {% if applicationState === 'submitted' %}
+    {% if applicationState === 'claimed' %}
+      <h1 class="govuk-heading-l">Application reference number is no longer valid.</h1>
+    {% else %}
       {{ govukPanel({
         titleText: "Record submitted",
         html: "Booking reference number<br><strong>" + reference + "</strong>"
@@ -18,8 +20,6 @@
       <p class="govuk-body">If you have a question about your submission, call the Rural Payments Agency on 03000 200 301.</p>
       <p class="govuk-body">Monday to Friday 8.30am to 5pm, except bank holidays.</p>
       <p><a href="https://www.gov.uk/call-charges" target="_blank">Find out about call charges</a></p>
-    {% else %}
-      <h1 class="govuk-heading-l">No application found, application reference number is no longer valid.</h1>
     {% endif %}
   </div>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-frontend",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Web front-end for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-frontend",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/vet/confirmation.test.js
+++ b/test/integration/narrow/routes/vet/confirmation.test.js
@@ -68,7 +68,7 @@ describe('Confirmation test', () => {
       expect(res.statusCode).toBe(200)
       const $ = cheerio.load(res.payload)
       expect($('h1').text()).toMatch(
-        'No application found, application reference number is no longer valid.'
+        'Application reference number is no longer valid.'
       )
       expectPhaseBanner.ok($)
     })

--- a/test/integration/narrow/routes/vet/confirmation.test.js
+++ b/test/integration/narrow/routes/vet/confirmation.test.js
@@ -4,16 +4,8 @@ const getCrumbs = require('../../../../utils/get-crumbs')
 
 const reference = 'VV-5874-0BFA'
 
-const mockMessage = {
-  sendMessage: () => {
-    return 'nothing'
-  },
-  receiveMessage: jest.fn().mockReturnValueOnce({
-    applicationState: 'submitted'
-  }).mockImplementationOnce({
-    applicationState: 'already_submitted'
-  })
-}
+const messagingMock = require('../../../../../app/messaging')
+jest.mock('../../../../../app/messaging')
 
 const mockSession = {
   getVetVisitData: () => {
@@ -29,9 +21,7 @@ const mockSession = {
     return { reference, applicationState: 'submitted' }
   }
 }
-
 jest.mock('../../../../../app/session', () => mockSession)
-jest.mock('../../../../../app/messaging', () => mockMessage)
 
 describe('Confirmation test', () => {
   const auth = { credentials: {}, strategy: 'cookie' }
@@ -43,6 +33,9 @@ describe('Confirmation test', () => {
 
   describe(`POST ${url} route`, () => {
     test('returns 200', async () => {
+      messagingMock.receiveMessage.mockResolvedValueOnce({
+        applicationState: 'not_claimed'
+      })
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         method: 'POST',
@@ -60,6 +53,9 @@ describe('Confirmation test', () => {
     })
 
     test('returns error message', async () => {
+      messagingMock.receiveMessage.mockResolvedValueOnce({
+        applicationState: 'claimed'
+      })
       const crumb = await getCrumbs(global.__SERVER__)
       const options = {
         method: 'POST',
@@ -71,7 +67,9 @@ describe('Confirmation test', () => {
       const res = await global.__SERVER__.inject(options)
       expect(res.statusCode).toBe(200)
       const $ = cheerio.load(res.payload)
-      expect($('h1').text()).toMatch('No application found, application reference number is no longer valid.')
+      expect($('h1').text()).toMatch(
+        'No application found, application reference number is no longer valid.'
+      )
       expectPhaseBanner.ok($)
     })
 


### PR DESCRIPTION
Fixes an issue when the vet resubmits the data, which is allowed now whilst it hasn't been claimed, but the view would state it wasn't available. Now the view correctly only displays that when the application has been claimed.

It could do with more refactoring to check the status prior to the sending of the message rather than afterwards, see #90 